### PR TITLE
Fix docify embed in md

### DIFF
--- a/README.md
+++ b/README.md
@@ -83,7 +83,7 @@ of files or individual files.
 In fact, this `README.md` file is automatically compiled whenever `cargo doc` is run on this
 crate, resulting in the following codeblock to populate dynamically:
 
-```rust
+```rust,ignore
 fn some_example() {
     assert_eq!(2 + 2, 4);
     assert_eq!(2 + 3, 5);

--- a/macros/src/lib.rs
+++ b/macros/src/lib.rs
@@ -600,16 +600,16 @@ impl Display for MarkdownLanguage {
         match self {
             MarkdownLanguage::Ignore => write!(f, "{}", "ignore"),
             MarkdownLanguage::Rust => write!(f, "{}", "rust"),
-            MarkdownLanguage::Blank => write(f, "", ""),
+            MarkdownLanguage::Blank => write!(f, "{}", ""),
         }
     }
 }
 
 /// Converts a source string to a codeblocks wrapped example
-fn into_example(st: &str, langs: Vec<MarkdownLanguage>) -> String {
+fn into_example(st: &str, langs: &Vec<MarkdownLanguage>) -> String {
     let mut lines: Vec<String> = Vec::new();
-
     // Add the markdown languages (can be more than one, or none)
+
     lines.push(String::from("```"));
     let mut langs_iter = langs.iter();
     langs_iter
@@ -1007,12 +1007,12 @@ fn embed_internal_str(
         for (item, style) in visitor.results {
             let excerpt = source_excerpt(&source_code, &item, style)?;
             let formatted = fix_indentation(excerpt);
-            let example = into_example(formatted.as_str(), langs);
+            let example = into_example(formatted.as_str(), &langs);
             results.push(example);
         }
         results.join("\n")
     } else {
-        into_example(source_code.as_str(), langs)
+        into_example(source_code.as_str(), &langs)
     };
     Ok(output)
 }

--- a/macros/src/lib.rs
+++ b/macros/src/lib.rs
@@ -608,16 +608,18 @@ impl Display for MarkdownLanguage {
 /// Converts a source string to a codeblocks wrapped example
 fn into_example(st: &str, langs: &Vec<MarkdownLanguage>) -> String {
     let mut lines: Vec<String> = Vec::new();
-    // Add the markdown languages (can be more than one, or none)
 
-    lines.push(String::from("```"));
-    let mut langs_iter = langs.iter();
-    langs_iter
-        .next()
-        .map(|first_lang| lines.push(first_lang.to_string()));
-    for lang in langs_iter {
-        lines.push(format!(",{}", lang.to_string()));
-    }
+    // Add the markdown languages (can be more than one, or none)
+    let mut lang_line = String::from("```");
+    lang_line.push_str(
+        langs
+            .iter()
+            .map(|lang| lang.to_string())
+            .collect::<Vec<String>>()
+            .join(",")
+            .as_str(),
+    );
+    lines.push(lang_line);
 
     for line in st.lines() {
         lines.push(String::from(line));

--- a/macros/src/tests.rs
+++ b/macros/src/tests.rs
@@ -66,7 +66,7 @@ fn test_compile_markdown_valid() {
             .to_string(),
         "\"# This is a markdown file\\n\\n```rust\\nstruct \
         Something;\\n```\\n<!-- this is a comment -->\\n\\n`\
-        ``rust\\nfn some_fn() {\\n    println!(\\\"foo\\\");\
+        ``rust,ignore\\nfn some_fn() {\\n    println!(\\\"foo\\\");\
         \\n}\\n```\\n\\nSome text this is some text\\n\""
     );
 }
@@ -96,7 +96,7 @@ fn test_compile_markdown_source_valid() {
         "this is some markdown\n\
         this is some more markdown\n\
         # this is a title\n\
-        ```rust\n\
+        ```rust,ignore\n\
         fn some_fn() {\n    \
             println!(\"foo\");\n\
         }\n\


### PR DESCRIPTION
When embedding Rust code samples in markdown files, this happens with `Rust` lang. If the READMEs are included as crate level docs for example, those code samples will represent down the line doc tests.

We want ideally for `docify::embed` to have the same functionality when used for markdown files as it has for regular `.rs` docs.

This PR adds support for multiple langs, specifically for the case of wrapping around Rust code samples with `rust,ignore`, and avoid having them interpreted as docs tests. 